### PR TITLE
Rename the Oni entity RO-Crate route to /entity/:id/metadata and correct the rocrate spelling

### DIFF
--- a/app/controllers/api/v1/oni_controller.rb
+++ b/app/controllers/api/v1/oni_controller.rb
@@ -145,7 +145,7 @@ module Api
           return
         end
 
-        @admin_rocrate = false
+        @admin_ro_crate = false
 
         @essence_terms_required = essence_terms_required?
 

--- a/app/controllers/api/v1/oni_controller.rb
+++ b/app/controllers/api/v1/oni_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class OniController < ApiController
-      skip_before_action :enforce_terms_acceptance, only: %i[capabilities entities entity rocrate search]
+      skip_before_action :enforce_terms_acceptance, only: %i[capabilities entities entity metadata search]
 
       rescue_from ActiveRecord::RecordNotFound do |exception|
         message = exception.message == 'ActiveRecord::RecordNotFound' ? 'The requested entity was not found' : exception.message
@@ -138,7 +138,7 @@ module Api
         end
       end
 
-      def rocrate
+      def metadata
         unless params[:id]
           render_api_error('VALIDATION_ERROR', 'id is required', :bad_request)
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -261,17 +261,17 @@ class CollectionsController < ApplicationController
     redirect_to location, allow_other_host: true
   end
 
-  def private_rocrate
+  def private_ro_crate
     @data = @collection
-    @admin_rocrate = true
+    @admin_ro_crate = true
 
     json_data = render_to_string(template: 'api/v1/oni/object_meta_collection', formats: [:json], handlers: [:jb])
     send_data json_data, filename: "#{@collection.identifier}-ro-crate-metadata.json", type: 'application/json', disposition: 'attachment'
   end
 
-  def public_rocrate
+  def public_ro_crate
     @data = @collection
-    @admin_rocrate = false
+    @admin_ro_crate = false
 
     json_data = render_to_string(template: 'api/v1/oni/object_meta_collection', formats: [:json], handlers: [:jb])
     send_data json_data, filename: "#{@collection.identifier}-ro-crate-metadata.json", type: 'application/json', disposition: 'attachment'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -168,17 +168,17 @@ class ItemsController < ApplicationController
     redirect_to bulk_update_items_path + "?#{params[:original_search_params]}"
   end
 
-  def private_rocrate
+  def private_ro_crate
     @data = @item
-    @admin_rocrate = true
+    @admin_ro_crate = true
 
     json_data = render_to_string(template: 'api/v1/oni/object_meta_item', formats: [:json], handlers: [:jb])
     send_data json_data, filename: "#{@item.full_identifier}-ro-crate-metadata.json", type: 'application/json', disposition: 'attachment'
   end
 
-  def public_rocrate
+  def public_ro_crate
     @data = @item
-    @admin_rocrate = false
+    @admin_ro_crate = false
 
     json_data = render_to_string(template: 'api/v1/oni/object_meta_item', formats: [:json], handlers: [:jb])
     send_data json_data, filename: "#{@item.full_identifier}-ro-crate-metadata.json", type: 'application/json', disposition: 'attachment'

--- a/app/jobs/catalog_metadata_job.rb
+++ b/app/jobs/catalog_metadata_job.rb
@@ -2,17 +2,17 @@ class CatalogMetadataJob < ApplicationJob
   queue_as :default
 
   def perform(data, is_item)
-    local_data = { data:, admin_rocrate: true }
+    local_data = { data:, admin_ro_crate: true }
 
 
-    filename = Nabu::Catalog::ADMIN_ROCRATE_FILENAME
+    filename = Nabu::Catalog::ADMIN_RO_CRATE_FILENAME
 
     if is_item
-      rocrate = Api::V1::OniController.render :object_meta_item, assigns: local_data
-      Nabu::Catalog.instance.upload_item_admin(data, filename, rocrate, 'application/json')
+      ro_crate = Api::V1::OniController.render :object_meta_item, assigns: local_data
+      Nabu::Catalog.instance.upload_item_admin(data, filename, ro_crate, 'application/json')
     else
-      rocrate = Api::V1::OniController.render :object_meta_collection, assigns: local_data
-      Nabu::Catalog.instance.upload_collection_admin(data, filename, rocrate, 'application/json')
+      ro_crate = Api::V1::OniController.render :object_meta_collection, assigns: local_data
+      Nabu::Catalog.instance.upload_collection_admin(data, filename, ro_crate, 'application/json')
     end
   end
 end

--- a/app/views/api/v1/oni/object_meta_collection.json.jb
+++ b/app/views/api/v1/oni/object_meta_collection.json.jb
@@ -4,7 +4,7 @@ def collection_id
   repository_collection_url(@data)
 end
 
-def collection_rocrate_json
+def collection_ro_crate_json
   {
     '@id': 'ro-crate-metadata.json',
     '@type': 'CreativeWork',
@@ -212,7 +212,7 @@ data = {
   countries: @data.countries.map { |country| { '@id': collection_country_json(country) } }
 }
 
-if @admin_rocrate
+if @admin_ro_crate
   data[:comment] = @data.comments
   data[:usageinfo] = @data.access_narrative if @data.access_narrative
   data[:private] = @data.private
@@ -239,7 +239,7 @@ data.compact!
 graph = []
 
 graph << data
-graph << collection_rocrate_json
+graph << collection_ro_crate_json
 
 # Add all the references
 graph.concat(@property_values.to_a)

--- a/app/views/api/v1/oni/object_meta_essence.json.jb
+++ b/app/views/api/v1/oni/object_meta_essence.json.jb
@@ -8,7 +8,7 @@ def essence_parent_id
   repository_item_url(@data.collection, @data.item)
 end
 
-def essence_rocrate_json
+def essence_ro_crate_json
   {
     '@id': 'ro-crate-metadata.json',
     '@type': 'CreativeWork',
@@ -51,7 +51,7 @@ data.compact!
 graph = []
 
 graph << data
-graph << essence_rocrate_json
+graph << essence_ro_crate_json
 
 {
   '@context': [

--- a/app/views/api/v1/oni/object_meta_item.json.jb
+++ b/app/views/api/v1/oni/object_meta_item.json.jb
@@ -4,7 +4,7 @@ def item_id
   repository_item_url(@data.collection, @data)
 end
 
-def item_rocrate_json
+def item_ro_crate_json
   {
     '@id': 'ro-crate-metadata.json',
     '@type': 'CreativeWork',
@@ -247,7 +247,7 @@ data = {
   countries: @data.countries.map { |country| { '@id': item_country_json(country) } }
 }
 
-if @admin_rocrate
+if @admin_ro_crate
   data[:comment] = @data.admin_comment
   data[:usageinfo] = @data.access_narrative if @data.access_narrative
   data[:private] = @data.private
@@ -284,7 +284,7 @@ end
   data[agent_role.name] = item_agents.map { |item_agent| { '@id': item_person_json(item_agent.user) } }
 end
 
-if @admin_rocrate
+if @admin_ro_crate
   data[:digitisedOn] = @data.digitised_on.to_date if @data.digitised_on
   data[:receivedOn] = @data.received_on.to_date if @data.received_on
   data[:bornDigital] = @data.born_digital
@@ -304,7 +304,7 @@ data.compact!
 graph = []
 
 graph << data
-graph << item_rocrate_json
+graph << item_ro_crate_json
 
 # Add all the references
 graph.concat(@property_values.to_a)

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -221,9 +221,9 @@
           %th RO-Crate Metadata
           %td
             %ul
-              %li= link_to 'Download', public_rocrate_collection_path(@collection)
+              %li= link_to 'Download', public_ro_crate_collection_path(@collection)
               - if admin_user_signed_in?
-                %li= link_to 'Download (with private metadata)', private_rocrate_collection_path(@collection)
+                %li= link_to 'Download (with private metadata)', private_ro_crate_collection_path(@collection)
 
   .right
     - if can? :destroy, @collection

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -296,9 +296,9 @@
         %th RO-Crate Metadata
         %td
           %ul
-            %li= link_to 'Download', public_rocrate_collection_item_path(@collection, @item)
+            %li= link_to 'Download', public_ro_crate_collection_item_path(@collection, @item)
             - if admin_user_signed_in?
-              %li= link_to 'Download (with private metadata)', private_rocrate_collection_item_path(@collection, @item)
+              %li= link_to 'Download (with private metadata)', private_ro_crate_collection_item_path(@collection, @item)
 
   %fieldset
     %legend Comments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,15 +55,15 @@ Rails.application.routes.draw do
       post 'spreadsheet' => 'collections#create_from_spreadsheet'
     end
     member do
-      get :private_rocrate
-      get :public_rocrate
+      get :private_ro_crate
+      get :public_ro_crate
       get :deposit_form
       get :essences_csv
     end
     resources :items, except: %i[index] do
       member do
-        get :private_rocrate
-        get :public_rocrate
+        get :private_ro_crate
+        get :public_ro_crate
         get :data
         patch :inherit_details
         get :essences_csv

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,7 @@ Rails.application.routes.draw do
         get 'capabilities' => 'oni#capabilities'
         get 'entities' => 'oni#entities'
         get 'entity/:id' => 'oni#entity', constraints: { id: %r{[^/]+} }
-        get 'entity/:id/rocrate' => 'oni#rocrate', constraints: { id: %r{[^/]+} }
+        get 'entity/:id/metadata' => 'oni#metadata', constraints: { id: %r{[^/]+} }
         get 'files' => 'oni#files'
         get 'file/:id' => 'oni#file', constraints: { id: %r{[^/]+} }
         get 'announcements' => 'oni#announcements'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
     volumes:
       - s3-data:/s3mockroot
 
-  oni-ui:
+  oni:
     ports:
       - "7000:80"
     build:

--- a/docker/oni.Dockerfile
+++ b/docker/oni.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/crate-works/oni:test-capabilities-segments
+FROM ghcr.io/crate-works/oni:2
 
 ARG ROCRATE_API_ENDPOINT
 ARG ROCRATE_API_CLIENTID

--- a/docker/oni.json
+++ b/docker/oni.json
@@ -157,23 +157,25 @@
         "text": "See this <span style=\"display: inline-flex; align-items: center;\"><a class=\"el-link el-link--primary\" target=\"_blank\" href=\"https://www.ldaca.edu.au/resources/user-guides/portal/cite-data/\">help</a></span> page for more detail."
       }
     },
-    "textReplacements": {
-      "^_": "",
-      "^ldac:doi$": "DOI",
-      "^paradisec:url$": "URL",
-      "^ldac:isDeIdentified$": "Is De-Identified",
-      "^citation$": "Related Works",
-      "^ldac:": "",
-      "^dct:": "",
-      "^local:": "",
-      "^prov:": "",
-      "^pcdm:": "",
-      "^isbn$": "ISBN",
-      "^issn$": "ISSN",
-      "^url$": "URL",
-      "^@id$": "ID",
-      "^@type$": "Type",
-      "^arcp://name,custom/terms#": ""
+    "metadataMapping": {
+      "textReplacements": {
+        "^_": "",
+        "^ldac:doi$": "DOI",
+        "^paradisec:url$": "URL",
+        "^ldac:isDeIdentified$": "Is De-Identified",
+        "^citation$": "Related Works",
+        "^ldac:": "",
+        "^dct:": "",
+        "^local:": "",
+        "^prov:": "",
+        "^pcdm:": "",
+        "^isbn$": "ISBN",
+        "^issn$": "ISSN",
+        "^url$": "URL",
+        "^@id$": "ID",
+        "^@type$": "Type",
+        "^arcp://name,custom/terms#": ""
+      }
     },
     "head": {
       "title": "DC.publisher",

--- a/lib/nabu/catalog.rb
+++ b/lib/nabu/catalog.rb
@@ -6,7 +6,7 @@ module Nabu
   class Catalog
     include Singleton
 
-    ADMIN_ROCRATE_FILENAME = 'ro-crate-metadata.json'.freeze
+    ADMIN_RO_CRATE_FILENAME = 'ro-crate-metadata.json'.freeze
     DEPOSIT_FORM_SUFFIX = '-deposit.pdf'.freeze
     DEPOSIT_FORM_KEY_PATTERN = %r{\A([^/]+)/\1#{Regexp.escape(DEPOSIT_FORM_SUFFIX)}\z}
 
@@ -37,12 +37,12 @@ module Nabu
       [essence.item.collection.identifier, essence.item.identifier, essence.filename].join('/')
     end
 
-    def item_rocrate_key(item)
-      item_admin_key(item, ADMIN_ROCRATE_FILENAME)
+    def item_ro_crate_key(item)
+      item_admin_key(item, ADMIN_RO_CRATE_FILENAME)
     end
 
-    def collection_rocrate_key(collection)
-      collection_admin_key(collection, ADMIN_ROCRATE_FILENAME)
+    def collection_ro_crate_key(collection)
+      collection_admin_key(collection, ADMIN_RO_CRATE_FILENAME)
     end
 
     def deposit_form_key(collection)
@@ -52,7 +52,7 @@ module Nabu
     # True for the admin files nabu writes alongside essences: RO-Crate metadata
     # at the collection/item root and the collection's deposit PDF.
     def admin_key?(key)
-      return true if key.end_with?("/#{ADMIN_ROCRATE_FILENAME}")
+      return true if key.end_with?("/#{ADMIN_RO_CRATE_FILENAME}")
 
       key.end_with?(DEPOSIT_FORM_SUFFIX) && key.match?(DEPOSIT_FORM_KEY_PATTERN)
     end
@@ -60,14 +60,14 @@ module Nabu
     # Every key that makes up an item in the bucket: its essence files plus its admin metadata.
     def item_keys(item)
       keys = item.essences.map { |essence| essence_key(essence) }
-      keys << item_rocrate_key(item)
+      keys << item_ro_crate_key(item)
       keys
     end
 
     # Every key that makes up a collection in the bucket: its items' keys plus its admin files.
     def collection_keys(collection)
       keys = collection.items.includes(:essences).flat_map { |item| item_keys(item) }
-      keys << collection_rocrate_key(collection)
+      keys << collection_ro_crate_key(collection)
       keys << deposit_form_key(collection)
       keys
     end

--- a/lib/oni/search_capabilities.rb
+++ b/lib/oni/search_capabilities.rb
@@ -3,9 +3,9 @@ module Oni
   # its accepted filter keys and type rules from FILTERS, and the controller's aggs must stay
   # within FACETS (the spec requires every facet to also be a filter).
   module SearchCapabilities
-    API_VERSION = '0.3.0'.freeze
+    API_VERSION = '0.4.0'.freeze
 
-    # Nabu is read-only: no deposit or RO-Crate write surface. Spec 0.3.0 requires the block of
+    # Nabu is read-only: no deposit or RO-Crate write surface. Spec 0.4.0 requires the block of
     # every implementation so clients never infer read-only-ness from a missing key, and requires
     # the remaining deposit fields to be omitted when supported is false.
     DEPOSIT = { supported: false }.freeze

--- a/lib/tasks/ro_crate.rake
+++ b/lib/tasks/ro_crate.rake
@@ -1,5 +1,5 @@
 # rubocop:disable Metrics/BlockLength
-namespace :rocrate do
+namespace :ro_crate do
   desc 'Generate ro-crate for a collection and save to S3'
   task :collection, [:identifier] => :environment do |task, args|
     raise 'Please pass a collection identifier' if args[:identifier].nil?

--- a/spec/jobs/catalog_metadata_job_spec.rb
+++ b/spec/jobs/catalog_metadata_job_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+# The admin flag is a nil-falsy ivar, so a producer that stops setting it downgrades the crate to
+# the public shape rather than raising.
+describe CatalogMetadataJob, :no_catalog_upload do
+  let(:catalog) { Nabu::Catalog.instance }
+
+  # additionalType appears only on the root entity of either template.
+  def uploaded_crate(record)
+    is_item = record.is_a?(Item)
+    uploaded = nil
+    upload = is_item ? :upload_item_admin : :upload_collection_admin
+    allow(catalog).to receive(upload) { |_record, _filename, data, _type| uploaded = data }
+
+    described_class.perform_now(record, is_item)
+
+    JSON.parse(uploaded)['@graph'].find { |node| node['additionalType'] }
+  end
+
+  # The literal, not the constant: renaming the constant must not move the key already in S3.
+  it 'writes the item crate under the admin metadata filename' do
+    item = create(:item)
+
+    expect(catalog).to receive(:upload_item_admin)
+      .with(item, 'ro-crate-metadata.json', kind_of(String), 'application/json')
+
+    described_class.perform_now(item, true)
+  end
+
+  it 'includes private metadata in the item crate' do
+    item = create(:item, ingest_notes: 'Tape was mouldy', private: true)
+
+    crate = uploaded_crate(item)
+
+    expect(crate['paradisec:ingestNotes']).to eq('Tape was mouldy')
+    expect(crate['private']).to be true
+  end
+
+  it 'includes private metadata in the collection crate' do
+    collection = create(:collection, comments: 'Deposited under embargo', private: true)
+
+    crate = uploaded_crate(collection)
+
+    expect(crate['comment']).to eq('Deposited under embargo')
+    expect(crate['private']).to be true
+  end
+end

--- a/spec/lib/nabu/catalog_spec.rb
+++ b/spec/lib/nabu/catalog_spec.rb
@@ -5,15 +5,15 @@ describe Nabu::Catalog do
   let(:collection) { build(:collection, identifier: 'AA1') }
   let(:item) { build(:item, identifier: '001', collection:) }
 
-  describe '#collection_rocrate_key' do
+  describe '#collection_ro_crate_key' do
     it 'lives at the collection root' do
-      expect(catalog.collection_rocrate_key(collection)).to eq('AA1/ro-crate-metadata.json')
+      expect(catalog.collection_ro_crate_key(collection)).to eq('AA1/ro-crate-metadata.json')
     end
   end
 
-  describe '#item_rocrate_key' do
+  describe '#item_ro_crate_key' do
     it 'lives at the item root' do
-      expect(catalog.item_rocrate_key(item)).to eq('AA1/001/ro-crate-metadata.json')
+      expect(catalog.item_ro_crate_key(item)).to eq('AA1/001/ro-crate-metadata.json')
     end
   end
 
@@ -25,8 +25,8 @@ describe Nabu::Catalog do
 
   describe '#admin_key?' do
     it 'recognises every admin key the builders produce' do
-      expect(catalog.admin_key?(catalog.collection_rocrate_key(collection))).to be true
-      expect(catalog.admin_key?(catalog.item_rocrate_key(item))).to be true
+      expect(catalog.admin_key?(catalog.collection_ro_crate_key(collection))).to be true
+      expect(catalog.admin_key?(catalog.item_ro_crate_key(item))).to be true
       expect(catalog.admin_key?(catalog.deposit_form_key(collection))).to be true
     end
 

--- a/spec/requests/api/v1/oni_capabilities_spec.rb
+++ b/spec/requests/api/v1/oni_capabilities_spec.rb
@@ -9,7 +9,7 @@ describe 'Oni capabilities', type: :request do
     expect(response).to have_http_status(:ok)
 
     body = response.parsed_body
-    expect(body['apiVersion']).to eq('0.3.0')
+    expect(body['apiVersion']).to eq('0.4.0')
     expect(body['extensions']).to eq('segments' => {})
     expect(body.dig('search', 'filters', 'originatedOn')).to eq('type' => 'date', 'label' => 'Date originated')
     expect(body.dig('search', 'filters', 'languages_with_code')).to eq('type' => 'string', 'label' => 'Language')
@@ -23,7 +23,7 @@ describe 'Oni capabilities', type: :request do
     expect(search['filters'].keys).to include(*search['facets'].keys)
   end
 
-  # Spec 0.3.0 requires both members of every implementation, read-only ones included.
+  # Spec 0.4.0 requires both members of every implementation, read-only ones included.
   it 'declares itself read-only, with no deposit fields beyond the supported flag' do
     get capabilities_path
 

--- a/spec/requests/api/v1/oni_object_meta_essence_spec.rb
+++ b/spec/requests/api/v1/oni_object_meta_essence_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-# The per-essence RO-Crate (oni#rocrate → object_meta_essence) must derive its
+# The per-essence RO-Crate (oni#metadata → object_meta_essence) must derive its
 # annotationOf / hasAnnotation links from stored essence_annotations mappings,
 # not by inferring relationships from filename basenames at render time.
 describe 'Oni essence RO-Crate annotations', :no_catalog_upload, type: :request do
@@ -10,9 +10,9 @@ describe 'Oni essence RO-Crate annotations', :no_catalog_upload, type: :request 
   # Guests can never read essences; any signed-in user can read essences on open items.
   before { sign_in create(:user) }
 
-  def rocrate_for(essence)
+  def metadata_for(essence)
     id = repository_essence_url(essence.collection, essence.item, essence.filename)
-    get "/api/v1/oni/entity/#{CGI.escape(id)}/rocrate"
+    get "/api/v1/oni/entity/#{CGI.escape(id)}/metadata"
 
     expect(response).to have_http_status(:ok)
     response.parsed_body['@graph'].find { |node| node['@id'] == id }
@@ -31,14 +31,14 @@ describe 'Oni essence RO-Crate annotations', :no_catalog_upload, type: :request 
     end
 
     it 'links the transcript to its media via annotationOf' do
-      file = rocrate_for(transcript)
+      file = metadata_for(transcript)
 
       expect(file['annotationOf']).to eq([{ '@id' => essence_id(media) }])
       expect(file).not_to have_key('hasAnnotation')
     end
 
     it 'links the media back to its transcript via hasAnnotation' do
-      file = rocrate_for(media)
+      file = metadata_for(media)
 
       expect(file['hasAnnotation']).to eq([{ '@id' => essence_id(transcript) }])
       expect(file).not_to have_key('annotationOf')
@@ -56,14 +56,14 @@ describe 'Oni essence RO-Crate annotations', :no_catalog_upload, type: :request 
     end
 
     it 'emits no annotation links for the transcript' do
-      file = rocrate_for(transcript)
+      file = metadata_for(transcript)
 
       expect(file).not_to have_key('annotationOf')
       expect(file).not_to have_key('hasAnnotation')
     end
 
     it 'emits no annotation links for the media' do
-      file = rocrate_for(media)
+      file = metadata_for(media)
 
       expect(file).not_to have_key('annotationOf')
       expect(file).not_to have_key('hasAnnotation')

--- a/spec/requests/api/v1/oni_object_meta_geometry_spec.rb
+++ b/spec/requests/api/v1/oni_object_meta_geometry_spec.rb
@@ -9,7 +9,7 @@ describe 'Oni RO-Crate geometry', :no_catalog_upload, type: :request do
   before { sign_in create(:user) }
 
   def wkt_for(record, url)
-    get "/api/v1/oni/entity/#{CGI.escape(url)}/rocrate"
+    get "/api/v1/oni/entity/#{CGI.escape(url)}/metadata"
 
     expect(response).to have_http_status(:ok)
     prefix = "#geo-#{record.west_limit},#{record.south_limit}-"

--- a/spec/services/collection_destruction_service_spec.rb
+++ b/spec/services/collection_destruction_service_spec.rb
@@ -14,8 +14,8 @@ describe CollectionDestructionService, :no_catalog_upload do
       catalog = Nabu::Catalog.instance
       expected_keys = [
         catalog.essence_key(essence),
-        catalog.item_rocrate_key(item),
-        catalog.collection_rocrate_key(collection),
+        catalog.item_ro_crate_key(item),
+        catalog.collection_ro_crate_key(collection),
         catalog.deposit_form_key(collection)
       ]
 

--- a/spec/services/item_destruction_service_spec.rb
+++ b/spec/services/item_destruction_service_spec.rb
@@ -15,7 +15,7 @@ describe ItemDestructionService, :no_catalog_upload do
     end
 
     it 'still schedules deletion of the admin metadata, verifying the item prefix' do
-      expected_keys = [catalog.item_rocrate_key(item_with_no_files)]
+      expected_keys = [catalog.item_ro_crate_key(item_with_no_files)]
 
       described_class.destroy(item_with_no_files)
 
@@ -28,7 +28,7 @@ describe ItemDestructionService, :no_catalog_upload do
     let(:item_with_files) { essence.item }
 
     it 'schedules deletion of the essence files and admin metadata, verifying the item prefix' do
-      expected_keys = [catalog.essence_key(essence), catalog.item_rocrate_key(item_with_files)]
+      expected_keys = [catalog.essence_key(essence), catalog.item_ro_crate_key(item_with_files)]
 
       response = described_class.destroy(item_with_files)
 


### PR DESCRIPTION
Spec: #1179 (supersedes #1178)

**Draft — do not merge yet.** All three commits are present, but two of the three release gates are still open; see *Outstanding* below. No closing keyword on this PR for that reason.

## What's here

**1. Conformance rename** (`924bacc2`)

`GET /api/v1/oni/entity/:id/rocrate` becomes `/entity/:id/metadata`, per RO-Crate API spec 0.4.0. Clean break — no alias, no redirect. The endpoint returns an RO-Crate Metadata Document rather than a package, so `rocrate` was wrong on terminology as well as spelling.

The `skip_before_action :enforce_terms_acceptance` list names actions by symbol, so it moves with the rename or terms enforcement silently starts applying to this endpoint. Rails maps `HEAD` onto the `GET` route, so the spec's `headEntityMetadata` rename needs no separate work.

`API_VERSION` follows to `0.4.0`. Deleting a path that 0.3.0 mandates while still advertising 0.3.0 would misreport the surface on the very endpoint clients read to decide what to call.

**2. Spelling cleanup** (`31154b02`)

`rocrate` → `ro_crate` across internal identifiers: the `@admin_ro_crate` flag and its six producers, `ADMIN_RO_CRATE_FILENAME`, the catalog key helpers, the view-local JSON builders, the rake namespace, and the Collection/Item download routes.

Internal names take the *spelling* fix, not the spec's terminology swap. `/entity/{id}/metadata` is disambiguated by the segments around it; a bare `@admin_metadata` or `item_metadata_key` would trade a precise misspelled name for a correct vague one in a codebase where collections, items and essences are all metadata. Deliberate consequence: the Oni action is `metadata` while the ivar it sets is `@admin_ro_crate`.

Adds `spec/jobs/catalog_metadata_job_spec.rb` — the job had no test at all despite running inline on almost every Collection and Item in the suite. The admin flag is a nil-falsy ivar, so a producer that stops setting it downgrades that crate to the public shape rather than raising.

## URL changes

| Before | After |
|---|---|
| `/api/v1/oni/entity/:id/rocrate` | `/api/v1/oni/entity/:id/metadata` |
| `/collections/:id/{private,public}_rocrate` | `/collections/:id/{private,public}_ro_crate` |
| `/collections/:cid/items/:id/{private,public}_rocrate` | `…/{private,public}_ro_crate` |
| `rake rocrate:*` | `rake ro_crate:*` |

**S3 keys and downloaded filenames do not move.** `ADMIN_RO_CRATE_FILENAME`'s *value* is unchanged, and the new job spec asserts the literal `'ro-crate-metadata.json'` rather than the constant so a future rename can't quietly move a key that already exists in the bucket.

## Deliberately unchanged

Oni's own `api.rocrate` config key and `ROCRATE_API_*` build args (Oni's schema, not this API); the CDK `rocrate-downloader` bucket (renaming means replacing it); `ROCRATE_API_BASE_URL` in the CDK app stack (a deploy-time env var, infra coordination rather than a spelling fix); the `object_meta_*.json.jb` template filenames (no misspelling to fix); and the Collections `metadata` route meaning "create from a spreadsheet".

## Outstanding

| Gate | State |
|---|---|
| `crate-works/ro-crate-api#37` merged | **Done** — merged via crate-works/ro-crate-api#38; the merged path is `/entity/{id}/metadata`, matching this branch exactly |
| Spec **0.4.0 tagged** | **Not done** — `openapi.yaml` still reads `version: 0.3.0`, the rename sits under `[Unreleased]`, and the repo has no tags at all |
| `crate-works/oni#51` shipped | **Not done** — still open; Oni's `main` has not yet moved its call site |

`API_VERSION` here advertises `0.4.0`, which does not exist upstream yet. That is the reason to hold this PR rather than a formality.

### On the pinned Oni tag

`fix: new oni for these changes` pins `ghcr.io/crate-works/oni:2`. Because `oni#51` is open, that image still calls `/entity/{id}/rocrate` — deploying this branch today gives 404s on entity metadata across the catalogue.

`:2` is a floating major tag (`crate-works/oni@711ce4c3`), so it self-heals once #51 merges and CI republishes — no re-pin needed. Two things follow:

- Deploy only **after** #51 lands and its image is republished.
- The pin is not reproducible by digest, and CDK builds Oni through `ContainerImage.fromAsset('../docker')`, whose asset hash derives from the Dockerfile text and build context rather than the resolved upstream digest. A later `cdk deploy` may reuse the cached asset and never re-pull `:2`; expect to force a rebuild to pick up the fixed Oni.

## Validation

- `bundle exec rspec` — 450 examples, 0 failures (7 pending are pre-existing `# fix this later` spreadsheet specs)
- `bundle exec rubocop` — 411 files, no offences
- `rails routes` confirms all four renamed download helpers match their view call sites; `rails -T` confirms the four rake tasks load under `ro_crate:`

## Known gap

Nothing in the suite renders the Collection or Item show pages, so the four renamed path helpers have no test coverage — verified against `rails routes` by inspection instead. Pre-existing; closing it properly needs a feature spec with admin auth and access-condition setup.

Review also flagged that the `@admin_ro_crate` flag has six producers with no shared seam, and that the four download actions are near-identical. Both are pre-existing structural issues that this rename surfaced rather than caused; worth a follow-up issue if you want one.
