### PR TITLE
feat: prepare the jobs service for maintenance work

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -567,6 +567,10 @@ export class AppStack extends cdk.Stack {
     );
     searchDomain.grantReadWrite(jobsTaskDefinition.taskRole);
     catalogBucket.grantReadWrite(jobsTaskDefinition.taskRole);
+    metaBucket.grantRead(jobsTaskDefinition.taskRole);
+    if (env === 'prod') {
+      metaDrBucket.grantRead(jobsTaskDefinition.taskRole);
+    }
 
     const jobsService = new ecs.Ec2Service(this, 'JobsService', {
       serviceName: 'jobs',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,6 +52,8 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue
   config.solid_queue.connects_to = { database: { writing: :queue } }
+  # Long enough that a weekly maintenance run is still visible in Mission Control a full cycle later.
+  config.solid_queue.clear_finished_jobs_after = 8.days
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,10 +3,13 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: "*"
+    - queues: default
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
       polling_interval: 0.1
+    - queues: maintenance
+      threads: 1
+      polling_interval: 10
 
 development:
   <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -12,6 +12,7 @@
 production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    queue: default
     schedule: every hour at minute 12
   annotation_reminder_digest:
     class: AnnotationReminderDigestJob

--- a/spec/config/queue_spec.rb
+++ b/spec/config/queue_spec.rb
@@ -17,10 +17,13 @@ describe 'config/queue.yml' do
     expect(workers.map { |worker| worker[:queues] }).not_to include('*')
   end
 
-  # Without the '*' worker, a queue nobody listens on silently strands its jobs.
+  # Without the '*' worker, a queue nobody listens on silently strands its jobs. A recurring task
+  # with no queue of its own falls back to its job class, and a command task to SolidQueue's own.
   it 'serves every queue the app can enqueue to' do
     Rails.application.eager_load!
-    recurring = Rails.application.config_for(:recurring, env: 'production').values.filter_map { |task| task[:queue] }
+    recurring = Rails.application.config_for(:recurring, env: 'production').each_value.map do |task|
+      task[:queue] || (task[:class] ? task[:class].constantize : SolidQueue::RecurringJob).new.queue_name
+    end
     enqueueable = ApplicationJob.descendants.map { |job| job.new.queue_name } + [ActiveJob::Base.new.queue_name] + recurring
 
     expect(enqueueable.uniq).to all(be_in(workers.map { |worker| worker[:queues] }))

--- a/spec/config/queue_spec.rb
+++ b/spec/config/queue_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+# A worker on '*' would let a multi-hour maintenance job take a thread from user-facing work.
+describe 'config/queue.yml' do
+  let(:workers) { Rails.application.config_for(:queue, env: 'production')[:workers] }
+
+  it 'gives the default queue a three-thread worker' do
+    expect(workers).to include(a_hash_including(queues: 'default', threads: 3))
+  end
+
+  it 'gives the maintenance queue a single-threaded worker' do
+    expect(workers).to include(a_hash_including(queues: 'maintenance', threads: 1))
+  end
+
+  it 'has no worker listening on every queue' do
+    expect(workers.map { |worker| worker[:queues] }).not_to include('*')
+  end
+
+  # Without the '*' worker, a queue nobody listens on silently strands its jobs.
+  it 'serves every queue the app can enqueue to' do
+    Rails.application.eager_load!
+    recurring = Rails.application.config_for(:recurring, env: 'production').values.filter_map { |task| task[:queue] }
+    enqueueable = ApplicationJob.descendants.map { |job| job.new.queue_name } + [ActiveJob::Base.new.queue_name] + recurring
+
+    expect(enqueueable.uniq).to all(be_in(workers.map { |worker| worker[:queues] }))
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/config/recurring_spec.rb
+++ b/spec/config/recurring_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+# Solid Queue only validates recurring tasks when the supervisor boots, so a renamed job or a bad
+# schedule would otherwise surface in production rather than in CI.
+describe 'config/recurring.yml' do
+  let(:tasks) { Rails.application.config_for(:recurring, env: 'production') }
+
+  it 'declares at least one production task' do
+    expect(tasks).not_to be_empty
+  end
+
+  it 'gives every task either a class or a command' do
+    expect(tasks.values).to all(include(:class).or(include(:command)))
+  end
+
+  it 'resolves every class-based task to an Active Job' do
+    classes = tasks.values.filter_map { |options| options[:class] }
+
+    expect(classes.map(&:safe_constantize)).to all(be < ActiveJob::Base)
+  end
+
+  it 'parses every schedule as a cron' do
+    schedules = tasks.values.map { |options| Fugit.parse(options[:schedule], multi: :fail) }
+
+    expect(schedules).to all(be_a(Fugit::Cron))
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/config/recurring_spec.rb
+++ b/spec/config/recurring_spec.rb
@@ -15,9 +15,12 @@ describe 'config/recurring.yml' do
   end
 
   it 'resolves every class-based task to an Active Job' do
-    classes = tasks.values.filter_map { |options| options[:class] }
+    tasks.values.filter_map { |options| options[:class] }.each do |name|
+      job_class = name.safe_constantize
 
-    expect(classes.map(&:safe_constantize)).to all(be < ActiveJob::Base)
+      expect(job_class).to be_present, "#{name} does not resolve to a class"
+      expect(job_class).to be < ActiveJob::Base
+    end
   end
 
   it 'parses every schedule as a cron' do


### PR DESCRIPTION
## What

First slice of #1193. Makes the existing `jobs` service able to host scheduled maintenance work, without adding any scheduled jobs yet.

- `config/queue.yml` replaces the single `*` worker with two under the same supervisor: `default` with three threads, `maintenance` with one. The maintenance worker polls every ten seconds, since nothing on that queue is latency sensitive.
- Production keeps finished job records for eight days, so a weekly run is still visible in Mission Control a full cycle later.
- The jobs ECS task role gains read on the meta bucket, and on the DR meta bucket in production.
- New specs guard both configuration files.

## Cleanup task fix

Removing the `*` worker exposed a latent trap. A command-based recurring task enqueues `SolidQueue::RecurringJob`, which declares its own `solid_queue_recurring` queue. The hourly finished-job cleanup is such a task, so it would have been enqueued every hour and never executed, keeping finished jobs forever. It is now pinned to the `default` queue.

The queue spec resolves each recurring task's effective queue rather than reading the `queue:` key, so it fails if any queue is left unserved. Verified by reverting the fix: the spec fails naming `solid_queue_recurring`.

## Note on the DR bucket grant

The DR meta bucket grant is gated to production. Granting it unconditionally makes the stage synth fail with `CannotUseCrossEnvironment`, because the DR stack lives in another region. The prod synth shows read on both buckets, which is what the acceptance criterion asks for. This mirrors the existing cron service, which grants the same buckets inside its own production-only block.

## Testing

- Full suite green: 462 examples, 0 failures, 7 pending.
- Rubocop clean on the changed Ruby.
- `cdk synth` passes for both the stage and production app stacks. The synthesised production template shows `s3:GetBucket*`, `s3:GetObject*` and `s3:List*` on the jobs task role for both meta buckets.

Part of #1193. Does not close #1194; the final ticket in the series opens the PR to `main`.

https://claude.ai/code/session_015E2BEBSR3wwWL3wQzZwXgh