### PR TITLE
fix: stop the S3 services altering process credentials

### DIFF
--- a/app/services/catalog_db_sync_validator_service.rb
+++ b/app/services/catalog_db_sync_validator_service.rb
@@ -9,11 +9,6 @@ class CatalogDbSyncValidatorService
     @catalog_bucket = "nabu-catalog-#{env}"
     @prefix = "inventories/catalog/nabu-catalog-#{env}/CatalogBucketInventory0/"
 
-    # Strange bug in dev docker
-    ENV.delete('AWS_SECRET_ACCESS_KEY')
-    ENV.delete('AWS_ACCESS_KEY_ID')
-    ENV.delete('AWS_SESSION_TOKEN')
-
     @s3 = Aws::S3::Client.new(region: 'ap-southeast-2')
   end
 

--- a/app/services/catalog_mediaflux_validator_service.rb
+++ b/app/services/catalog_mediaflux_validator_service.rb
@@ -3,11 +3,6 @@ require 'aws-sdk-s3'
 
 class CatalogMediafluxValidatorService
   def initialize
-    # Strange bug in dev docker
-    ENV.delete('AWS_SECRET_ACCESS_KEY')
-    ENV.delete('AWS_ACCESS_KEY_ID')
-    ENV.delete('AWS_SESSION_TOKEN')
-
     @s3 = Aws::S3::Client.new(region: 'ap-southeast-2')
   end
 

--- a/app/services/catalog_replication_validator_service.rb
+++ b/app/services/catalog_replication_validator_service.rb
@@ -5,11 +5,6 @@ class CatalogReplicationValidatorService
   attr_reader :catalog_dir, :verbose
 
   def initialize
-    # Strange bug in dev docker
-    ENV.delete('AWS_SECRET_ACCESS_KEY')
-    ENV.delete('AWS_ACCESS_KEY_ID')
-    ENV.delete('AWS_SESSION_TOKEN')
-
     @s3 = Aws::S3::Client.new(region: 'ap-southeast-2')
   end
 

--- a/app/services/junk_service.rb
+++ b/app/services/junk_service.rb
@@ -11,11 +11,6 @@ class JunkService
     @bucket = "nabu-catalog-#{env}"
     @verbose = verbose
 
-    # Strange bug in dev docker
-    ENV.delete('AWS_SECRET_ACCESS_KEY')
-    ENV.delete('AWS_ACCESS_KEY_ID')
-    ENV.delete('AWS_SESSION_TOKEN')
-
     @s3 = Aws::S3::Client.new(region: 'ap-southeast-2')
    end
 

--- a/app/services/s3_version_deletion_service.rb
+++ b/app/services/s3_version_deletion_service.rb
@@ -10,11 +10,6 @@ class S3VersionDeletionService
     @bucket = "nabu-catalog-#{env}"
     @verbose = verbose
 
-    # Strange bug in dev docker
-    ENV.delete('AWS_SECRET_ACCESS_KEY')
-    ENV.delete('AWS_ACCESS_KEY_ID')
-    ENV.delete('AWS_SESSION_TOKEN')
-
     @s3 = Aws::S3::Client.new(region: 'ap-southeast-2')
 
     @count = Hash.new(0)

--- a/bin/nabu_run
+++ b/bin/nabu_run
@@ -2,6 +2,11 @@
 
 touch .irb_history
 
+# An empty AWS_PROFILE is not the same as an unset one: the SDK reads it as a
+# profile named "" instead of falling back to default or an SSO session.
+aws_profile=()
+[ -n "$AWS_PROFILE" ] && aws_profile=(-e AWS_PROFILE="$AWS_PROFILE")
+
 docker compose run \
   --rm \
   -v "$PWD":/rails \
@@ -12,7 +17,7 @@ docker compose run \
   -e SENTRY_API_TOKEN="$SENTRY_API_TOKEN" \
   -e OPENID_SIGNING_KEY="$OPENID_SIGNING_KEY" \
   -e ELASTICSEARCH_URL="$(grep ^ELASTICSEARCH_URL .env | sed 's/^.*=//')" \
-  -e AWS_PROFILE="$AWS_PROFILE" \
+  "${aws_profile[@]}" \
   -v "$SSH_AUTH_SOCK:/tmp/ssh.sock" \
   -v "$PWD"/.irb_history:/home/rails/.irb_history \
   app \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,11 @@ services:
       context: .
       dockerfile: docker/app.dev.Dockerfile
     environment:
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+      # Null values, so an unset variable is absent in the container rather than
+      # forwarded as an empty string the SDK would prefer over the mounted profile.
+      AWS_ACCESS_KEY_ID:
+      AWS_SECRET_ACCESS_KEY:
+      AWS_SESSION_TOKEN:
       NABU_CATALOG_BUCKET: nabu-catalog-prod
       OPENSEARCH_URL: http://admin:fqo6bzr27*6Rdsshgsa7@search:9200
       OPENID_SIGNING_KEY: ${OPENID_SIGNING_KEY}

--- a/spec/services/s3_service_credentials_spec.rb
+++ b/spec/services/s3_service_credentials_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+# The validators run inside the shared jobs worker, where mutating the process
+# environment on construction would change credentials for every other thread.
+# The rake-only services are held to the same rule so none of them can be moved
+# into a job and reintroduce it.
+describe 'S3 service AWS credentials' do
+  def credential_vars = %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN]
+
+  def aws_credentials = ENV.to_hash.slice(*credential_vars)
+
+  around do |example|
+    original = aws_credentials
+
+    ENV['AWS_ACCESS_KEY_ID'] = 'AKIAEXAMPLE'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'secret'
+    ENV['AWS_SESSION_TOKEN'] = 'token'
+
+    example.run
+
+    credential_vars.each { |var| ENV.delete(var) }
+    ENV.update(original)
+  end
+
+  it 'survives constructing the DB sync validator' do
+    expect { CatalogDbSyncValidatorService.new('prod') }.not_to(change { aws_credentials })
+  end
+
+  it 'survives constructing the replication validator' do
+    expect { CatalogReplicationValidatorService.new }.not_to(change { aws_credentials })
+  end
+
+  it 'survives constructing the Mediaflux validator' do
+    expect { CatalogMediafluxValidatorService.new }.not_to(change { aws_credentials })
+  end
+
+  it 'survives constructing the junk service' do
+    expect { JunkService.new('prod') }.not_to(change { aws_credentials })
+  end
+
+  it 'survives constructing the S3 version deletion service' do
+    expect { S3VersionDeletionService.new('prod') }.not_to(change { aws_credentials })
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## What

Third slice of #1193, on the `solid-queue-recurring` integration branch. The catalogue validators stop deleting the AWS credential variables from the process environment.

Once these run inside the shared jobs worker, `ENV.delete` on construction changes credentials for every other thread in that process, so it has to go before #1199 turns them into recurring jobs.

## Fixing the cause, not just the symptom

The workaround was there for a real reason: dev docker forwarded the host shell's AWS variables as **empty strings** when they were unset, and the SDK prefers an empty variable over the mounted profile. Rather than delete the variables in application code, the compose file now declares them with null values, so an unset variable is *absent* in the container instead of empty.

Verified with a throwaway compose file:

| Host variable | `VAR: ${VAR}` (before) | `VAR:` (after) |
|---|---|---|
| unset | `VAR=` (empty) | not set at all |
| set | passed through | passed through |

`bin/nabu_run` had the same defect for `AWS_PROFILE`, and that one bites harder. aws-sdk-core resolves the profile with `ret ||= ENV['AWS_PROFILE']`, and an empty string is truthy in Ruby, so an empty value selects a profile literally named `""` rather than falling back. Confirmed in the container:

```
empty  -> ""
absent -> "default"
```

It is now only passed when set.

## Scope

The ticket named the three catalogue validators. `JunkService` and `S3VersionDeletionService` carried an identical copy of the workaround, including the same `# Strange bug in dev docker` comment. They are rake-only so removing it changes nothing today, but the bug it worked around no longer exists, and a stale workaround invites reintroduction. Cleaned up on John's say-so. `grep -rn 'ENV.delete' app/ lib/` now returns nothing.

## Testing

A spec asserts that constructing each of the five services leaves the credential variables in the process environment. It was run red before the change — all three validators took the environment from populated to `{}` — and green after.

The two dev-docker acceptance criteria were verified end to end through `./bin/nabu_run` rather than by reading the config:

- Nothing set in the host shell: no credential variables reach the container and the profile resolves to `default`, so the SDK falls back to the mounted `~/.aws`.
- Variables set in the host shell: all four pass through unchanged.

Full suite green: 469 examples, 0 failures, 7 pending (all pre-existing). Rubocop clean on the changed Ruby.

## A note on the test run

The first few full-suite runs for this branch failed heavily (342 failures, then `index_not_found_exception` storms). None of it was this branch. Another session was running the suite against the same shared `-p nabu` stack — one `nabu_test` database, one OpenSearch instance — and the two runs were deleting each other's Searchkick indices and dropping each other's database. We coordinated and took turns; both branches then came back clean.

Worth fixing separately: a per-worktree compose project name would isolate the database, the indices and the app container in one change. Raised with John rather than changed here.

Part of #1193. Does not close #1196; the final ticket in the series opens the PR to `main`.

https://claude.ai/code/session_015E2BEBSR3wwWL3wQzZwXgh
