### PR TITLE
feat: run the catalogue validators as recurring jobs

### DIFF
--- a/app/jobs/validate_catalog_db_sync_job.rb
+++ b/app/jobs/validate_catalog_db_sync_job.rb
@@ -1,0 +1,7 @@
+class ValidateCatalogDbSyncJob < ApplicationJob
+  queue_as :maintenance
+
+  def perform
+    CatalogDbSyncValidatorService.new('prod').run
+  end
+end

--- a/app/jobs/validate_catalog_mediaflux_job.rb
+++ b/app/jobs/validate_catalog_mediaflux_job.rb
@@ -1,0 +1,7 @@
+class ValidateCatalogMediafluxJob < ApplicationJob
+  queue_as :maintenance
+
+  def perform
+    CatalogMediafluxValidatorService.new.run
+  end
+end

--- a/app/jobs/validate_catalog_replication_job.rb
+++ b/app/jobs/validate_catalog_replication_job.rb
@@ -1,0 +1,7 @@
+class ValidateCatalogReplicationJob < ApplicationJob
+  queue_as :maintenance
+
+  def perform
+    CatalogReplicationValidatorService.new.run
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -18,3 +18,16 @@ production:
     class: AnnotationReminderDigestJob
     queue: default
     schedule: every day at 8am
+  validate_catalog_db_sync:
+    class: ValidateCatalogDbSyncJob
+    queue: maintenance
+    schedule: "0 16 * * mon"
+  validate_catalog_replication:
+    class: ValidateCatalogReplicationJob
+    queue: maintenance
+    schedule: "0 16 * * tue"
+  # Two hours after the 18:00 UTC Mediaflux inventory export, so it reads the same night's snapshot.
+  validate_catalog_mediaflux:
+    class: ValidateCatalogMediafluxJob
+    queue: maintenance
+    schedule: "0 20 * * wed"

--- a/cron-worker/cron.rb
+++ b/cron-worker/cron.rb
@@ -22,48 +22,9 @@ ensure
   super
 end
 
-scheduler.cron '27 4 * * tue'  do
-  name = 'Check DB S3 Sync'
-  task = 'catalog:check_db_s3_sync'
-
-  puts "#{Time.current}: Starting task #{name}"
-
-  begin
-    Rake::Task[task].invoke
-  ensure
-    Rake::Task[task].reenable
-  end
-end
-
-scheduler.cron '27 5 * * tue'  do
-  name = 'Check Replication'
-  task = 'catalog:check_replication'
-
-  puts "#{Time.current}: Starting task #{name}"
-
-  begin
-    Rake::Task[task].invoke
-  ensure
-    Rake::Task[task].reenable
-  end
-end
-
 scheduler.cron '27 5 * * wed'  do
   name = 'Delete unconfirmed users'
   task = 'users:delete_unconfirmed'
-
-  puts "#{Time.current}: Starting task #{name}"
-
-  begin
-    Rake::Task[task].invoke
-  ensure
-    Rake::Task[task].reenable
-  end
-end
-
-scheduler.cron '27 6 * * wed'  do
-  name = 'Check Mediaflux'
-  task = 'catalog:check_mediaflux'
 
   puts "#{Time.current}: Starting task #{name}"
 

--- a/lib/tasks/catalog.rake
+++ b/lib/tasks/catalog.rake
@@ -1,6 +1,6 @@
 namespace :catalog do
   desc 'Validate S3 vs DB'
-  task check_db_s3_sync: :environment do
+  task validate_db_sync: :environment do
     exit unless Rails.env.production?
 
     validator = CatalogDbSyncValidatorService.new('prod')
@@ -8,7 +8,7 @@ namespace :catalog do
   end
 
   desc 'Validate DR Replication'
-  task check_replication: :environment do
+  task validate_replication: :environment do
     validator = CatalogReplicationValidatorService.new
     validator.run
   end
@@ -33,7 +33,7 @@ namespace :catalog do
   end
 
   desc 'Validate Catalog vs Mediaflux'
-  task check_mediaflux: :environment do
+  task validate_mediaflux: :environment do
     validator = CatalogMediafluxValidatorService.new
     validator.run
   end

--- a/spec/jobs/validate_catalog_db_sync_job_spec.rb
+++ b/spec/jobs/validate_catalog_db_sync_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe ValidateCatalogDbSyncJob do
+  it 'runs the DB sync validator against the production buckets' do
+    validator = instance_double(CatalogDbSyncValidatorService)
+
+    allow(CatalogDbSyncValidatorService).to receive(:new).with('prod').and_return(validator)
+    expect(validator).to receive(:run)
+
+    described_class.perform_now
+  end
+
+  it 'runs on the maintenance queue' do
+    expect(described_class.new.queue_name).to eq('maintenance')
+  end
+end

--- a/spec/jobs/validate_catalog_mediaflux_job_spec.rb
+++ b/spec/jobs/validate_catalog_mediaflux_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe ValidateCatalogMediafluxJob do
+  it 'runs the Mediaflux validator' do
+    validator = instance_double(CatalogMediafluxValidatorService)
+
+    allow(CatalogMediafluxValidatorService).to receive(:new).with(no_args).and_return(validator)
+    expect(validator).to receive(:run)
+
+    described_class.perform_now
+  end
+
+  it 'runs on the maintenance queue' do
+    expect(described_class.new.queue_name).to eq('maintenance')
+  end
+end

--- a/spec/jobs/validate_catalog_replication_job_spec.rb
+++ b/spec/jobs/validate_catalog_replication_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe ValidateCatalogReplicationJob do
+  it 'runs the replication validator' do
+    validator = instance_double(CatalogReplicationValidatorService)
+
+    allow(CatalogReplicationValidatorService).to receive(:new).with(no_args).and_return(validator)
+    expect(validator).to receive(:run)
+
+    described_class.perform_now
+  end
+
+  it 'runs on the maintenance queue' do
+    expect(described_class.new.queue_name).to eq('maintenance')
+  end
+end


### PR DESCRIPTION
## What

Fourth slice of #1193, on the `solid-queue-recurring` integration branch. The three weekly catalogue validators become Solid Queue recurring jobs.

Three thin jobs on the `maintenance` queue delegate to the existing services, so each service can still be run synchronously from a console or rake task:

| Job | Delegates to | Schedule (UTC) |
|---|---|---|
| `ValidateCatalogDbSyncJob` | DB sync validator, `prod` bucket suffix | Monday 16:00 |
| `ValidateCatalogReplicationJob` | replication validator | Tuesday 16:00 |
| `ValidateCatalogMediafluxJob` | Mediaflux validator | Wednesday 20:00 |

The Mediaflux slot is two hours after the nightly 18:00 UTC inventory export, so it validates against the same night's snapshot rather than the previous one.

No environment guard in the jobs — the `production` key in the recurring configuration is the only gate. No retries, so an S3 or Mediaflux outage fails the run visibly rather than starting a retry storm; the next scheduled run is the retry.

## Rake tasks

Kept as manual entry points, renamed to match the jobs: `catalog:validate_db_sync`, `catalog:validate_replication`, `catalog:validate_mediaflux`. The DB sync task keeps its production-only guard, which protects manual invocation. `grep` confirms no references to the old names remain anywhere.

The three cron entries are removed. What is left in the cron script is DOI minting (#1197) and unconfirmed-user deletion (#1198).

## Testing

A spec per job at the `perform_now` seam stubs the validator service and asserts it is constructed with the expected arguments and run, plus that the job declares the `maintenance` queue.

I checked these specs actually have teeth rather than trusting a green tick: changing the DB sync job to pass `'stage'` instead of `'prod'` fails with `received :new with unexpected arguments / expected: ("prod")`. Reverted after confirming.

The existing `config/recurring.yml` spec covers the three new entries automatically — every class constantises to an `ActiveJob` subclass and every schedule parses as a Fugit cron. The `config/queue.yml` spec independently confirms `maintenance` is a queue a worker actually serves, so none of these can be enqueued into a void.

Full suite green: 475 examples, 0 failures, 7 pending (all pre-existing). Rubocop clean.

Part of #1193. Does not close #1199; the final ticket in the series opens the PR to `main`.

https://claude.ai/code/session_015E2BEBSR3wwWL3wQzZwXgh
